### PR TITLE
feat - 공통 dialog 기능 추가

### DIFF
--- a/domain/src/main/java/com/hugg/domain/model/enums/DialogType.kt
+++ b/domain/src/main/java/com/hugg/domain/model/enums/DialogType.kt
@@ -1,0 +1,5 @@
+package com.hugg.domain.model.enums
+
+enum class DialogType {
+    SINGLE, DOUBLE
+}

--- a/feature/src/main/java/com/hugg/feature/component/HuggDialog.kt
+++ b/feature/src/main/java/com/hugg/feature/component/HuggDialog.kt
@@ -1,0 +1,122 @@
+package com.hugg.feature.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.hugg.domain.model.enums.DialogType
+import com.hugg.feature.theme.Black
+import com.hugg.feature.theme.Gs10
+import com.hugg.feature.theme.Gs80
+import com.hugg.feature.theme.HuggTypography
+import com.hugg.feature.theme.MainNormal
+import com.hugg.feature.theme.WORD_NO
+import com.hugg.feature.theme.WORD_YES
+import com.hugg.feature.theme.White
+
+@Composable
+fun HuggDialog(
+    title : String = "",
+    dialogType : DialogType = DialogType.DOUBLE,
+    negativeColor : Color = Gs10,
+    positiveColor : Color = MainNormal,
+    negativeText : String = WORD_NO,
+    positiveText : String = WORD_YES,
+    onClickNegative : () -> Unit = {},
+    onClickPositive : () -> Unit = {},
+    onClickCancel : () -> Unit = {},
+){
+    Dialog(
+        onDismissRequest = onClickCancel,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ){
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .fillMaxWidth()
+                .height(164.dp)
+                .background(color = White, shape = RoundedCornerShape(12.dp))
+        ) {
+            Spacer(modifier = Modifier.size(40.dp))
+
+            Text(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .fillMaxWidth(),
+                maxLines = 1,
+                text = title,
+                style = HuggTypography.h2,
+                color = Black,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Row(
+                modifier = Modifier.padding(horizontal = 16.dp)
+            ) {
+                if(dialogType == DialogType.DOUBLE) {
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(48.dp)
+                            .background(color = negativeColor, shape = RoundedCornerShape(4.dp))
+                            .clickable(
+                                onClick = onClickNegative,
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = negativeText,
+                            style = HuggTypography.h2,
+                            color = Gs80
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.size(8.dp))
+                }
+
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(48.dp)
+                        .background(color = positiveColor, shape = RoundedCornerShape(4.dp))
+                        .clickable(
+                            onClick = onClickPositive,
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null
+                        ),
+                    contentAlignment = Alignment.Center
+                ){
+                    Text(
+                        text = positiveText,
+                        style = HuggTypography.h2,
+                        color = White
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.size(16.dp))
+        }
+    }
+}

--- a/feature/src/main/java/com/hugg/feature/theme/StringComponent.kt
+++ b/feature/src/main/java/com/hugg/feature/theme/StringComponent.kt
@@ -10,6 +10,9 @@ const val WORD_NEXT = "다음"
 const val WORD_DAILY_RECORD = "하루기록"
 const val WORD_SIGN_UP = "회원가입"
 const val WORD_ROUND = "회차"
+const val WORD_NO = "아니요"
+const val WORD_YES = "네"
+const val WORD_REMOVE = "삭제"
 
 // --------- 기타 --------- //
 const val COPY_COMPLETE_TEXT = "클립보드에 배우자 코드가 복사되었어요!"


### PR DESCRIPTION
## 이슈 번호
> 작업이 완료된 이슈의 번호를 기록해주세요.
9번

## 작업내용
> 작업한 내용을 설명해주세요. 왜 수정했는지? 무엇을 구현했는지? 등등
공통으로 사용되는 Dialog 컴포넌트를 제작했습니다 아래는 코드 및 사용법입니다

```
fun HuggDialog(
    title : String = "",  // dialog content 문구입니다.
    dialogType : DialogType = DialogType.DOUBLE, // dialog의 버튼을 보여주는 타입입니다. 1개는 SINGLE, 2개는 DOUBLE로 명시했습니다.
    negativeColor : Color = Gs10, // 부정 버튼의 색상입니다. 특별한 경우가 아니라면 변수로 넘길 필요 없습니다.
    positiveColor : Color = MainNormal, // 긍정 버튼의 색상입니다. 특별한 경우가 아니라면 변수로 넘길 필요 없습니다.
    negativeText : String = WORD_NO, // 부정 버튼의 글자 입니다. "아니요" 가 기본값 입니다.
    positiveText : String = WORD_YES, // 긍정 버튼의 글자 입니다. "예" 가 기본값 입니다.
    onClickNegative : () -> Unit = {}, // 부정 버튼을 클릭시 동작하는 함수 입니다.
    onClickPositive : () -> Unit = {}, // 긍정 버튼을 클릭시 동작하는 함수 입니다.
    onClickCancel : () -> Unit = {}, // dialog 외부 영역을 터치 시 실행되는 함수 입니다.
)
```

## 결과물
> 구현한 것 스크린샷 또는 영상 또는 gif 형태로 올려주세요.
<img width="256" alt="스크린샷 2024-08-31 오후 12 48 54" src="https://github.com/user-attachments/assets/56d6e40b-3646-4ad8-9bcd-6fc368380bb3">
버튼 2개 dialog

<img width="256" alt="스크린샷 2024-08-31 오후 12 54 18" src="https://github.com/user-attachments/assets/43bb771e-ad78-4dc0-96f2-37712a1f4e3f">
버튼 1개 dialog


## 리뷰어에게 추가로 요구하는 사항(선택)
> 이 부분을 자세히 봐야한다 또는 함수 로직에 확신이 없는데 더 좋은 방법이 있을까요? 등등
따로 없습니당 가계부 작업에 필요한 내용이라 빠르게 리뷰 부탁드립니다!
