### PR TITLE
[ Feat ] 캘린더 바텀네비 추가

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -39,8 +39,8 @@ object AndroidX{
     const val COMPOSE_BOM = "androidx.compose:compose-bom:${Versions.COMPOSE_BOM}"
     const val COMPOSE_UI = "androidx.compose.ui:ui"
     const val COMPOSE_GRAPHICS = "androidx.compose.ui:ui-graphics"
-    const val COMPOSE_PREVIEW = "androidx.compose.ui:ui-tooling-preview"
-    const val COMPOSE_MATERIAL = "androidx.compose.material3:material3"
+    const val COMPOSE_PREVIEW = "androidx.compose.ui:ui-tooling-preview:${Versions.COMPOSE_PREVIEW}"
+    const val COMPOSE_MATERIAL = "androidx.compose.material3:material3:${Versions.COMPOSE_MATERIAL3}"
 }
 
 object Libraries {

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -28,6 +28,8 @@ object Versions {
     const val DATA_STORE = "1.0.0"
     const val ACTIVITY_COMPOSE = "1.8.2"
     const val COMPOSE_BOM = "2023.08.00"
+    const val COMPOSE_MATERIAL3 = "1.1.0"
+    const val COMPOSE_PREVIEW = "1.5.0"
 
     /* [ Libraries ] */
     const val RETROFIT = "2.9.0"

--- a/domain/src/main/java/com/hugg/domain/model/enums/BottomNavType.kt
+++ b/domain/src/main/java/com/hugg/domain/model/enums/BottomNavType.kt
@@ -1,5 +1,5 @@
 package com.hugg.domain.model.enums
 
 enum class BottomNavType {
-    CALENDAR, ACCOUNT, HOME, INFO, PROFILE, OTHER
+    CALENDAR, ACCOUNT, HOME, DAILY_HUGG, PROFILE, OTHER
 }

--- a/feature/calendar/src/main/java/com/hugg/calendar/calendarMain/CalendarScreen.kt
+++ b/feature/calendar/src/main/java/com/hugg/calendar/calendarMain/CalendarScreen.kt
@@ -95,7 +95,7 @@ fun CalendarContainer(
         viewModel.eventFlow.collect { event ->
             when(event){
                 is CalendarEvent.GoToCreateSchedule -> { navigateCreateSchedule(CreateOrEditType.CREATE, event.type, -1, event.day) }
-                CalendarEvent.ShowErrorMaxScheduleEvent -> HuggToast.createToast(context, CALENDAR_TOAST_SUCCESS_CREATE, true).show()
+                CalendarEvent.ShowErrorMaxScheduleEvent -> HuggToast.createToast(context, CALENDAR_MAX_SCHEDULE, true).show()
             }
         }
     }

--- a/feature/main/src/main/java/com/hugg/main/MainPageState.kt
+++ b/feature/main/src/main/java/com/hugg/main/MainPageState.kt
@@ -1,0 +1,8 @@
+package com.hugg.main
+
+import com.hugg.domain.model.enums.BottomNavType
+import com.hugg.feature.base.PageState
+
+data class MainPageState(
+    val pageType : BottomNavType = BottomNavType.OTHER
+) : PageState

--- a/feature/main/src/main/java/com/hugg/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/hugg/main/MainScreen.kt
@@ -1,29 +1,241 @@
 package com.hugg.main
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
+import com.hugg.domain.model.enums.BottomNavType
+import com.hugg.feature.theme.Gs50
+import com.hugg.feature.theme.Gs80
 import com.hugg.feature.theme.HuggTheme
+import com.hugg.feature.theme.HuggTypography
+import com.hugg.feature.theme.WORD_ACCOUNT
+import com.hugg.feature.theme.WORD_CALENDAR
+import com.hugg.feature.theme.WORD_DAILY_HUGG
+import com.hugg.feature.theme.WORD_HOME
+import com.hugg.feature.theme.WORD_MY
+import com.hugg.feature.theme.White
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Composable
-fun MainScreen() {
+fun MainScreen(
+    viewModel : MainViewModel = hiltViewModel()
+) {
     val navController = rememberNavController()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val interactionSource = remember { MutableInteractionSource() }
+
+
+    LaunchedEffect(navController) {
+        navController.currentBackStackEntryFlow
+            .distinctUntilChanged()
+            .collect { backStackEntry ->
+                viewModel.changedRoute(backStackEntry.destination.route)
+            }
+    }
 
     HuggTheme {
-        // A surface container using the 'background' color from the theme
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background
         ) {
-            NavHost(navController = navController, startDestination = Routes.SignGraph.route) {
-                signNavGraph(navController)
-                calendarGraph(navController)
-                accountGraph(navController)
+            Column(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f)
+                ) {
+                    NavHost(navController = navController, startDestination = Routes.SignGraph.route) {
+                        signNavGraph(navController)
+                        calendarGraph(navController)
+                        accountGraph(navController)
+                    }
+                }
+
+                // BottomNavView를 하단에 고정
+                if (uiState.pageType != BottomNavType.OTHER) {
+                    BottomNavView(
+                        type = uiState.pageType,
+                        interactionSource = interactionSource,
+                        navigateToRoute = { route -> navController.navigate(route) }
+                    )
+                }
             }
+        }
+    }
+}
+
+@Composable
+fun BottomNavView(
+    type : BottomNavType = BottomNavType.OTHER,
+    navigateToRoute : (String) -> Unit = {},
+    interactionSource: MutableInteractionSource
+){
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(color = White)
+            .padding(horizontal = 20.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(
+            modifier = Modifier
+                .clickable(
+                    onClick = {
+                        if(type == BottomNavType.HOME) return@clickable
+                        //navigateToRoute()
+                    },
+                    interactionSource = interactionSource,
+                    indication = null
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ){
+            Box(modifier = Modifier
+                .padding(top = 6.dp, start = 10.dp, end = 10.dp)
+                .size(28.dp)
+                .background(Gs50)
+            )
+            Spacer(modifier = Modifier.size(3.dp))
+
+            Text(
+                modifier = Modifier.padding(bottom = 1.dp),
+                text = WORD_HOME,
+                style = HuggTypography.p4,
+                color = if(type == BottomNavType.HOME) Gs80 else Gs50
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .clickable(
+                    onClick = {
+                        if(type == BottomNavType.CALENDAR) return@clickable
+                        navigateToRoute(Routes.CalendarGraph.route)
+                    },
+                    interactionSource = interactionSource,
+                    indication = null
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ){
+            Box(modifier = Modifier
+                .padding(top = 6.dp, start = 10.dp, end = 10.dp)
+                .size(28.dp)
+                .background(Gs50)
+            )
+            Spacer(modifier = Modifier.size(3.dp))
+
+            Text(
+                modifier = Modifier.padding(bottom = 1.dp),
+                text = WORD_CALENDAR,
+                style = HuggTypography.p4,
+                color = if(type == BottomNavType.CALENDAR) Gs80 else Gs50
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .clickable(
+                    onClick = {
+                        if(type == BottomNavType.DAILY_HUGG) return@clickable
+                        //navigateToRoute(Routes.CalendarGraph.route)
+                    },
+                    interactionSource = interactionSource,
+                    indication = null
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ){
+            Box(modifier = Modifier
+                .padding(top = 6.dp, start = 10.dp, end = 10.dp)
+                .size(28.dp)
+                .background(Gs50)
+            )
+            Spacer(modifier = Modifier.size(3.dp))
+
+            Text(
+                modifier = Modifier.padding(bottom = 1.dp),
+                text = WORD_DAILY_HUGG,
+                style = HuggTypography.p4,
+                color = if(type == BottomNavType.DAILY_HUGG) Gs80 else Gs50
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .clickable(
+                    onClick = {
+                        if(type == BottomNavType.ACCOUNT) return@clickable
+                        navigateToRoute(Routes.AccountGraph.route)
+                    },
+                    interactionSource = interactionSource,
+                    indication = null
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ){
+            Box(modifier = Modifier
+                .padding(top = 6.dp, start = 10.dp, end = 10.dp)
+                .size(28.dp)
+                .background(Gs50)
+            )
+            Spacer(modifier = Modifier.size(3.dp))
+
+            Text(
+                modifier = Modifier.padding(bottom = 1.dp),
+                text = WORD_ACCOUNT,
+                style = HuggTypography.p4,
+                color = if(type == BottomNavType.ACCOUNT) Gs80 else Gs50
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .clickable(
+                    onClick = {
+                        if(type == BottomNavType.PROFILE) return@clickable
+                        //navigateToRoute(Routes.CalendarGraph.route)
+                    },
+                    interactionSource = interactionSource,
+                    indication = null
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ){
+            Box(modifier = Modifier
+                .padding(top = 6.dp, start = 10.dp, end = 10.dp)
+                .size(28.dp)
+                .background(Gs50)
+            )
+            Spacer(modifier = Modifier.size(3.dp))
+
+            Text(
+                modifier = Modifier.padding(bottom = 1.dp),
+                text = WORD_MY,
+                style = HuggTypography.p4,
+                color = if(type == BottomNavType.PROFILE) Gs80 else Gs50
+            )
         }
     }
 }

--- a/feature/main/src/main/java/com/hugg/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/hugg/main/MainViewModel.kt
@@ -1,0 +1,26 @@
+package com.hugg.main
+
+import com.hugg.domain.model.enums.BottomNavType
+import com.hugg.feature.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+) : BaseViewModel<MainPageState>(MainPageState()) {
+
+    fun changedRoute(route : String?){
+        val type = when(route){
+            Routes.CalendarScreen.route -> BottomNavType.CALENDAR
+            Routes.AccountScreen.route -> BottomNavType.ACCOUNT
+            else -> BottomNavType.OTHER
+        }
+
+        updatePageType(type)
+    }
+    private fun updatePageType(type : BottomNavType){
+        updateState(
+            uiState.value.copy(pageType = type)
+        )
+    }
+}

--- a/feature/main/src/main/java/com/hugg/main/Routes.kt
+++ b/feature/main/src/main/java/com/hugg/main/Routes.kt
@@ -1,8 +1,5 @@
 package com.hugg.main
 
-import com.hugg.domain.model.enums.CreateOrEditType
-import com.hugg.domain.model.enums.RecordType
-
 sealed class Routes(val route : String){
 
     //----------------SIGN_GRAPH----------------//

--- a/feature/src/main/java/com/hugg/feature/theme/HuggTypography.kt
+++ b/feature/src/main/java/com/hugg/feature/theme/HuggTypography.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
 import com.hugg.feature.R
 
 fun Dp.toSp(): TextUnit = TextUnit(value = this.value, type = TextUnitType.Sp)
@@ -110,8 +111,8 @@ object HuggTypography {
 
     val p4: TextStyle = TextStyle(
         fontSize = 10.dp.toSp(),
-        lineHeight = 14.dp.toSp(),
-        letterSpacing = -0.03.dp.toSp(),
+        lineHeight = 10.dp.toSp(),
+        letterSpacing = (-0.03).em,
         fontFamily = huggFontFamily,
         fontWeight = FontWeight.Medium,
     )

--- a/feature/src/main/java/com/hugg/feature/theme/StringComponent.kt
+++ b/feature/src/main/java/com/hugg/feature/theme/StringComponent.kt
@@ -5,6 +5,9 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 
 // --------- 단어 --------- //
+const val WORD_HOME = "홈"
+const val WORD_DAILY_HUGG = "데일리 허그"
+const val WORD_MY = "마이"
 const val WORD_SKIP = "skip"
 const val WORD_NEXT = "다음"
 const val WORD_DAILY_RECORD = "하루기록"

--- a/feature/src/main/java/com/hugg/feature/theme/StringComponent.kt
+++ b/feature/src/main/java/com/hugg/feature/theme/StringComponent.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.text.withStyle
 // --------- 단어 --------- //
 const val WORD_HOME = "홈"
 const val WORD_DAILY_HUGG = "데일리 허그"
-const val WORD_MY = "마이"
+const val WORD_MY = "마정"
 const val WORD_SKIP = "skip"
 const val WORD_NEXT = "다음"
 const val WORD_DAILY_RECORD = "하루기록"


### PR DESCRIPTION
## 이슈 번호
> 작업이 완료된 이슈의 번호를 기록해주세요.

#26 

## 작업내용
> 작업한 내용을 설명해주세요. 왜 수정했는지? 무엇을 구현했는지? 등등

바텀 네비게이션 기능을 구현했습니다. 아직 아이콘은 확정이 아니라 box로 넣었고, 캘린더, 가계부만 추가한 상태입니다.
```
Column(
            modifier = Modifier
                .clickable(
                    onClick = {
                        if(type == BottomNavType.ACCOUNT) return@clickable
                        navigateToRoute(Routes.AccountGraph.route)
                    },
                    interactionSource = interactionSource,
                    indication = null
                ),
            horizontalAlignment = Alignment.CenterHorizontally
        )
```
위 코드처럼 onClick 안에 Route를 추가해주시면 됩니다!

## 결과물
> 구현한 것 스크린샷 또는 영상 또는 gif 형태로 올려주세요.

<img width="336" alt="스크린샷 2024-09-18 오후 9 51 30" src="https://github.com/user-attachments/assets/90d0f6c9-d0d9-45e5-8e9c-beba42382293">


## 리뷰어에게 추가로 요구하는 사항(선택)
> 이 부분을 자세히 봐야한다 또는 함수 로직에 확신이 없는데 더 좋은 방법이 있을까요? 등등
