### PR TITLE
[ Feat ] - throttleClick 기능 추가, 캘린더 오류 수정

### DIFF
--- a/feature/calendar/src/main/java/com/hugg/calendar/calendarMain/CalendarScreen.kt
+++ b/feature/calendar/src/main/java/com/hugg/calendar/calendarMain/CalendarScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import com.google.accompanist.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
@@ -63,6 +64,7 @@ import com.hugg.feature.theme.*
 import com.hugg.feature.uiItem.ScheduleDetailItem
 import com.hugg.feature.util.HuggToast
 import com.hugg.feature.util.TimeFormatter
+import com.hugg.feature.util.onThrottleClick
 
 
 @Composable
@@ -464,22 +466,28 @@ fun DialogCreateMode(
             exit = fadeOut(animationSpec = tween(300))
         ) {
 
-            Row(
+            LazyRow(
                 modifier = Modifier
-                    .padding(start = 14.dp)
-                    .horizontalScroll(rememberScrollState()),
+                    .padding(start = 14.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                CancelBtn(onClickBtn = onClickCreateCancelScheduleBtn, interactionSource = interactionSource)
-
-                Spacer(modifier = Modifier.size(8.dp))
-
-                CreateScheduleBtnByType(RecordType.HOSPITAL, onClickCreateScheduleBtn, interactionSource)
-                CreateScheduleBtnByType(RecordType.INJECTION, onClickCreateScheduleBtn, interactionSource)
-                CreateScheduleBtnByType(RecordType.MEDICINE, onClickCreateScheduleBtn, interactionSource)
-                CreateScheduleBtnByType(RecordType.ETC, onClickCreateScheduleBtn, interactionSource)
-
-                Spacer(modifier = Modifier.size(16.dp))
+                item {
+                    CancelBtn(onClickBtn = onClickCreateCancelScheduleBtn, interactionSource = interactionSource)
+                    Spacer(modifier = Modifier.size(8.dp))
+                }
+                item {
+                    CreateScheduleBtnByType(RecordType.HOSPITAL, onClickCreateScheduleBtn, interactionSource)
+                }
+                item {
+                    CreateScheduleBtnByType(RecordType.INJECTION, onClickCreateScheduleBtn, interactionSource)
+                }
+                item {
+                    CreateScheduleBtnByType(RecordType.MEDICINE, onClickCreateScheduleBtn, interactionSource)
+                }
+                item {
+                    CreateScheduleBtnByType(RecordType.ETC, onClickCreateScheduleBtn, interactionSource)
+                    Spacer(modifier = Modifier.size(16.dp))
+                }
             }
         }
 
@@ -506,10 +514,9 @@ fun CreateScheduleBtnByType(
                 color = MainNormal,
                 shape = RoundedCornerShape(999.dp)
             )
-            .clickable(
-                onClick = { onClickCreateScheduleBtn(type, 0) },
-                interactionSource = interactionSource,
-                indication = null
+            .onThrottleClick(
+                onClick = { onClickCreateScheduleBtn(type, 0) } ,
+                interactionSource = interactionSource
             )
             .background(color = White)
             .padding(horizontal = 9.dp, vertical = 6.dp),

--- a/feature/calendar/src/main/java/com/hugg/calendar/scheduleCreateOrEdit/HospitalCreateOrEditScreen.kt
+++ b/feature/calendar/src/main/java/com/hugg/calendar/scheduleCreateOrEdit/HospitalCreateOrEditScreen.kt
@@ -321,7 +321,7 @@ fun InputHospitalMemoView(
     Text(
         text = WORD_MEMO,
         style = HuggTypography.h3,
-        color = Gs50,
+        color = Gs80,
     )
 
     Spacer(modifier = Modifier.size(4.dp))
@@ -351,9 +351,6 @@ fun InputHospitalMemoView(
                 textStyle = HuggTypography.h3.copy(
                     color = Gs90,
                     textAlign = TextAlign.Start
-                ),
-                keyboardOptions = KeyboardOptions.Default.copy(
-                    keyboardType = KeyboardType.Number
                 ),
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth()

--- a/feature/calendar/src/main/java/com/hugg/calendar/scheduleCreateOrEdit/InjMedCreateOrEditScreen.kt
+++ b/feature/calendar/src/main/java/com/hugg/calendar/scheduleCreateOrEdit/InjMedCreateOrEditScreen.kt
@@ -845,9 +845,6 @@ fun InputMemoView(
                     color = Gs90,
                     textAlign = TextAlign.Start
                 ),
-                keyboardOptions = KeyboardOptions.Default.copy(
-                    keyboardType = KeyboardType.Number
-                ),
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth()
             )

--- a/feature/src/main/java/com/hugg/feature/uiItem/ScheduleDetailItem.kt
+++ b/feature/src/main/java/com/hugg/feature/uiItem/ScheduleDetailItem.kt
@@ -130,7 +130,7 @@ fun ScheduleDetailItem(
             ) {
                 Spacer(modifier = Modifier.size(14.dp))
 
-                Image(
+                if(scheduleDetailVo.recordType == RecordType.INJECTION || scheduleDetailVo.recordType == RecordType.MEDICINE) Image(
                     painter = painterResource(if(scheduleDetailVo.vibration) R.drawable.ic_vibration_alarm else R.drawable.ic_push_alarm),
                     contentDescription = null
                 )

--- a/feature/src/main/java/com/hugg/feature/util/ThrottleClickInterface.kt
+++ b/feature/src/main/java/com/hugg/feature/util/ThrottleClickInterface.kt
@@ -1,0 +1,61 @@
+package com.hugg.feature.util
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+interface ThrottleClickInterface {
+    fun event(event: () -> Unit)
+}
+
+@Composable
+fun <T> throttleClickEvent(
+    content: @Composable (ThrottleClickInterface) -> T,
+): T {
+    val interval = 500L
+    var canClick by remember { mutableStateOf(true) }
+
+    val result = content(
+        object : ThrottleClickInterface {
+            override fun event(event: () -> Unit) {
+                if (canClick) {
+                    canClick = false
+                    event()
+
+                    CoroutineScope(Dispatchers.Main).launch {
+                        delay(interval)
+                        canClick = true
+                    }
+                }
+            }
+        }
+    )
+
+    return result
+}
+
+@Composable
+fun Modifier.onThrottleClick(
+    onClick: () -> Unit,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) = composed {
+    throttleClickEvent { manager ->
+        this.then(
+            clickable(
+                onClick = { manager.event { onClick() } },
+                indication = null,
+                interactionSource = interactionSource
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 이슈 번호
> 작업이 완료된 이슈의 번호를 기록해주세요.

#29 

## 작업내용
> 작업한 내용을 설명해주세요. 왜 수정했는지? 무엇을 구현했는지? 등등

ThrottleClick 기능과 달력에서 발생한 오류를 수정했습니다. (메모 글자 색, 키보드 입력 타입 등)

주요 기능은 ThrottleClick 입니다. 딜레이는 0.5초로 설정했고 사용방법은 아래와 같습니다.

```
Modifier.onThrottleClick(
                onClick = { onClickCreateScheduleBtn(type, 0) } ,
                interactionSource = interactionSource
            )
```

구현 방법은 간단하게 state와 Coroutine을 이용해서 0.5초 동안 최초 클릭 이후 연타하는 클릭을 못하도록 막았습니다.

## 결과물
> 구현한 것 스크린샷 또는 영상 또는 gif 형태로 올려주세요.


https://github.com/user-attachments/assets/719c2d16-7f3c-4b8e-a5e9-bc2011faca32



## 리뷰어에게 추가로 요구하는 사항(선택)
> 이 부분을 자세히 봐야한다 또는 함수 로직에 확신이 없는데 더 좋은 방법이 있을까요? 등등

좀 더 효율적이거나 성능 개선이 가능한 부분이 있다면 코멘트 남겨주십쇼!
