### PR TITLE
[ Feat ] 홈 화면 데일리 허그 기능 추가 / 각종 오류 해결

### DIFF
--- a/data/src/main/java/com/hugg/data/api/ScheduleApi.kt
+++ b/data/src/main/java/com/hugg/data/api/ScheduleApi.kt
@@ -21,6 +21,7 @@ interface ScheduleApi {
     companion object{
         const val PATH_ID = "id"
         const val QUERY_YEAR_AND_MONTH = "yearmonth"
+        const val QUERY_TIME = "time"
     }
     @PUT(Endpoints.RECORD.MODIFY)
     suspend fun modify(
@@ -61,6 +62,7 @@ interface ScheduleApi {
 
     @PATCH(Endpoints.RECORD.CHECK_TODO)
     suspend fun checkTodoSchedule(
-        @Path(PATH_ID) id : Long
+        @Path(PATH_ID) id : Long,
+        @Query(QUERY_TIME) time : String,
     ) : Response<ApiResponse<Unit>>
 }

--- a/data/src/main/java/com/hugg/data/repository/ScheduleRepositoryImpl.kt
+++ b/data/src/main/java/com/hugg/data/repository/ScheduleRepositoryImpl.kt
@@ -47,7 +47,7 @@ class ScheduleRepositoryImpl @Inject constructor(
         return apiLaunch(apiCall = { scheduleApi.getMedicalRecordAndSideEffect(id) }, ScheduleSideEffectResponseMapper)
     }
 
-    override suspend fun checkTodoRecord(id: Long): Flow<ApiState<Unit>> {
-        return apiLaunch(apiCall = { scheduleApi.checkTodoSchedule(id) }, UnitResponseMapper)
+    override suspend fun checkTodoRecord(id: Long, time : String): Flow<ApiState<Unit>> {
+        return apiLaunch(apiCall = { scheduleApi.checkTodoSchedule(id, time) }, UnitResponseMapper)
     }
 }

--- a/domain/src/main/java/com/hugg/domain/model/response/home/HomeRecordResponseVo.kt
+++ b/domain/src/main/java/com/hugg/domain/model/response/home/HomeRecordResponseVo.kt
@@ -8,8 +8,8 @@ data class HomeRecordResponseVo(
     val id: Long = -1,
     @SerializedName("recordType")
     val recordType: RecordType = RecordType.ETC,
-    @SerializedName("times")
-    val times: List<String> = emptyList(),
+    @SerializedName("time")
+    val time: String = "",
     @SerializedName("name")
     val name: String = "",
     @SerializedName("memo")

--- a/domain/src/main/java/com/hugg/domain/repository/ScheduleRepository.kt
+++ b/domain/src/main/java/com/hugg/domain/repository/ScheduleRepository.kt
@@ -15,5 +15,5 @@ interface ScheduleRepository {
     suspend fun modifySchedule(id : Long, request : ScheduleDetailRequestVo) : Flow<ApiState<Unit>>
     suspend fun addMedicalRecord(id : Long, request : AddMedicalRecordRequest) : Flow<ApiState<Unit>>
     suspend fun getMedicalRecordAndSideEffect(id : Long) : Flow<ApiState<MedicalRecord>>
-    suspend fun checkTodoRecord(id : Long) : Flow<ApiState<Unit>>
+    suspend fun checkTodoRecord(id : Long, time : String) : Flow<ApiState<Unit>>
 }

--- a/feature/account/src/main/java/com/hugg/account/accountCreateOrEdit/AccountCreateOrEditScreen.kt
+++ b/feature/account/src/main/java/com/hugg/account/accountCreateOrEdit/AccountCreateOrEditScreen.kt
@@ -53,6 +53,7 @@ import com.hugg.feature.R
 import com.hugg.feature.component.FilledBtn
 import com.hugg.feature.component.HuggDialog
 import com.hugg.feature.component.HuggText
+import com.hugg.feature.component.HuggTextField
 import com.hugg.feature.util.HuggToast
 import com.hugg.feature.util.TimeFormatter
 import com.hugg.feature.util.UnitFormatter
@@ -433,7 +434,7 @@ fun ContentAndAmountView(
             )
         }
 
-        BasicTextField(
+        HuggTextField(
             value = content,
             onValueChange = { value ->
                 onChangedContent(value)
@@ -443,11 +444,6 @@ fun ContentAndAmountView(
             ),
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
-            decorationBox = { innerTextField ->
-                CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                    innerTextField()
-                }
-            }
         )
     }
 
@@ -524,7 +520,7 @@ fun ExpenditureItemView(
                 )
             }
 
-            BasicTextField(
+            HuggTextField(
                 value = TextFieldValue(
                     text = item.money,
                     selection = TextRange(item.money.length)
@@ -543,11 +539,6 @@ fun ExpenditureItemView(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 18.dp),
-                decorationBox = { innerTextField ->
-                    CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                        innerTextField()
-                    }
-                }
             )
         }
     }
@@ -580,7 +571,7 @@ fun InputMemoView(
             )
         }
 
-        BasicTextField(
+        HuggTextField(
             value = memo,
             onValueChange = { value ->
                 onChangedMemo(value)
@@ -590,11 +581,6 @@ fun InputMemoView(
             ),
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
-            decorationBox = { innerTextField ->
-                CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                    innerTextField()
-                }
-            }
         )
     }
 }

--- a/feature/account/src/main/java/com/hugg/account/accountMain/AccountScreen.kt
+++ b/feature/account/src/main/java/com/hugg/account/accountMain/AccountScreen.kt
@@ -72,6 +72,7 @@ import com.hugg.feature.R
 import com.hugg.feature.component.HuggDialog
 import com.hugg.feature.component.HuggTabBar
 import com.hugg.feature.component.HuggText
+import com.hugg.feature.component.HuggTextField
 import com.hugg.feature.component.PlusBtn
 import com.hugg.feature.component.TopBar
 import com.hugg.feature.theme.ACCOUNT_ALL
@@ -523,7 +524,7 @@ fun AccountTotalBox(
                     }
                 }
 
-                BasicTextField(
+                HuggTextField(
                     value = uiState.memo,
                     onValueChange = { value ->
                         onChangedMemo(value)
@@ -534,11 +535,6 @@ fun AccountTotalBox(
                     keyboardActions = KeyboardActions(onDone = {onKeyboardDone()}),
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
-                    decorationBox = { innerTextField ->
-                        CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                            innerTextField()
-                        }
-                    }
                 )
             }
         }

--- a/feature/account/src/main/java/com/hugg/account/subsidyCreateOrEdit/SubsidyCreateOrEditScreen.kt
+++ b/feature/account/src/main/java/com/hugg/account/subsidyCreateOrEdit/SubsidyCreateOrEditScreen.kt
@@ -46,6 +46,7 @@ import com.hugg.domain.model.enums.TopBarRightType
 import com.hugg.feature.component.FilledBtn
 import com.hugg.feature.component.HuggDialog
 import com.hugg.feature.component.HuggText
+import com.hugg.feature.component.HuggTextField
 import com.hugg.feature.component.TopBar
 import com.hugg.feature.theme.ACCOUNT_ADD_SUBSIDY
 import com.hugg.feature.theme.ACCOUNT_CONTENT_TEXT_FIELD_HINT
@@ -243,7 +244,7 @@ fun InputNickName(
                 )
             }
 
-            BasicTextField(
+            HuggTextField(
                 value = nickname,
                 onValueChange = { value ->
                     onChangedNickname(value)
@@ -253,11 +254,6 @@ fun InputNickName(
                 ),
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
-                decorationBox = { innerTextField ->
-                    CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                        innerTextField()
-                    }
-                }
             )
         }
 
@@ -307,7 +303,7 @@ fun InputContent(
                 )
             }
 
-            BasicTextField(
+            HuggTextField(
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(focusRequester),
@@ -318,11 +314,6 @@ fun InputContent(
                 textStyle = HuggTypography.h3.copy(
                     color = Gs90,
                 ),
-                decorationBox = { innerTextField ->
-                    CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                        innerTextField()
-                    }
-                }
             )
         }
     }
@@ -370,7 +361,7 @@ fun InputMoney(
                 )
             }
 
-            BasicTextField(
+            HuggTextField(
                 value = TextFieldValue(
                     text = money,
                     selection = TextRange(money.length)
@@ -389,11 +380,6 @@ fun InputMoney(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 18.dp),
-                decorationBox = { innerTextField ->
-                    CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                        innerTextField()
-                    }
-                }
             )
         }
     }

--- a/feature/calendar/src/main/java/com/hugg/calendar/scheduleCreateOrEdit/EtcCreateOrEditScreen.kt
+++ b/feature/calendar/src/main/java/com/hugg/calendar/scheduleCreateOrEdit/EtcCreateOrEditScreen.kt
@@ -34,6 +34,7 @@ import com.hugg.domain.model.enums.RepeatDayType
 import com.hugg.feature.R
 import com.hugg.feature.component.FilledBtn
 import com.hugg.feature.component.HuggText
+import com.hugg.feature.component.HuggTextField
 import com.hugg.feature.theme.CALENDAR_SCHEDULE_ETC_CONTENT_HINT
 import com.hugg.feature.theme.CALENDAR_SCHEDULE_ETC_CONTENT_TITLE
 import com.hugg.feature.theme.CALENDAR_SCHEDULE_ETC_TIME_PICKER_TITLE
@@ -138,7 +139,7 @@ fun InputEtcContentView(
                 )
             }
 
-            BasicTextField(
+            HuggTextField(
                 value = content,
                 onValueChange = { value ->
                     onChangedName(value)
@@ -152,11 +153,6 @@ fun InputEtcContentView(
                 ),
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
-                decorationBox = { innerTextField ->
-                    CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                        innerTextField()
-                    }
-                }
             )
         }
     }

--- a/feature/calendar/src/main/java/com/hugg/calendar/scheduleCreateOrEdit/HospitalCreateOrEditScreen.kt
+++ b/feature/calendar/src/main/java/com/hugg/calendar/scheduleCreateOrEdit/HospitalCreateOrEditScreen.kt
@@ -43,6 +43,7 @@ import com.hugg.domain.model.enums.RepeatDayType
 import com.hugg.feature.R
 import com.hugg.feature.component.FilledBtn
 import com.hugg.feature.component.HuggText
+import com.hugg.feature.component.HuggTextField
 import com.hugg.feature.theme.CALENDAR_SCHEDULE_DATE_AND_TIME_PICKER
 import com.hugg.feature.theme.CALENDAR_SCHEDULE_HOSPITAL_MEMO_HINT
 import com.hugg.feature.theme.CALENDAR_SCHEDULE_HOSPITAL_TREATMENT_CONTENT
@@ -163,7 +164,7 @@ internal fun InputTreatmentView(
                     )
                 }
 
-                BasicTextField(
+                HuggTextField(
                     value = kind,
                     onValueChange = { value ->
                         onChangedKind(value)
@@ -173,11 +174,6 @@ internal fun InputTreatmentView(
                         textAlign = TextAlign.Start
                     ),
                     singleLine = true,
-                    decorationBox = { innerTextField ->
-                        CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                            innerTextField()
-                        }
-                    }
                 )
             }
 
@@ -270,7 +266,7 @@ internal fun SelectDateAndTimeView(
 
         Spacer(modifier = Modifier.width(16.dp))
 
-        Text(
+        HuggText(
             color = Gs50,
             style = HuggTypography.h3,
             text = date
@@ -313,7 +309,7 @@ internal fun SelectDateAndTimeView(
 
         Spacer(modifier = Modifier.width(16.dp))
 
-        Text(
+        HuggText(
             color = Gs50,
             style = HuggTypography.h3,
             text = time
@@ -326,7 +322,7 @@ fun InputHospitalMemoView(
     memo : String = "",
     onChangedMemo : (String) -> Unit = {},
 ){
-    Text(
+    HuggText(
         text = WORD_MEMO,
         style = HuggTypography.h3,
         color = Gs80,
@@ -344,14 +340,14 @@ fun InputHospitalMemoView(
                 .padding(horizontal = 12.dp, vertical = 13.dp)
         ) {
             if (memo.isEmpty()) {
-                Text(
+                HuggText(
                     text = CALENDAR_SCHEDULE_HOSPITAL_MEMO_HINT,
                     style = HuggTypography.h3,
                     color = Gs50,
                 )
             }
 
-            BasicTextField(
+            HuggTextField(
                 value = memo,
                 onValueChange = { value ->
                     onChangedMemo(value)
@@ -362,11 +358,6 @@ fun InputHospitalMemoView(
                 ),
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
-                decorationBox = { innerTextField ->
-                    CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                        innerTextField()
-                    }
-                }
             )
         }
     }

--- a/feature/calendar/src/main/java/com/hugg/calendar/scheduleCreateOrEdit/InjMedCreateOrEditScreen.kt
+++ b/feature/calendar/src/main/java/com/hugg/calendar/scheduleCreateOrEdit/InjMedCreateOrEditScreen.kt
@@ -54,6 +54,7 @@ import com.hugg.domain.model.vo.calendar.RepeatTimeVo
 import com.hugg.feature.R
 import com.hugg.feature.component.FilledBtn
 import com.hugg.feature.component.HuggText
+import com.hugg.feature.component.HuggTextField
 import com.hugg.feature.theme.ACCOUNT_CREATE_CONTENT_HINT
 import com.hugg.feature.theme.ACCOUNT_CREATE_DATE_TITLE
 import com.hugg.feature.theme.ACCOUNT_ROUND_UNIT_WITHOUT_CAR
@@ -251,7 +252,7 @@ internal fun InputKindView(
                     )
                 }
 
-                BasicTextField(
+                HuggTextField(
                     value = kind,
                     onValueChange = { value ->
                         onChangedKind(value)
@@ -261,11 +262,6 @@ internal fun InputKindView(
                         textAlign = TextAlign.Start
                     ),
                     singleLine = true,
-                    decorationBox = { innerTextField ->
-                        CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                            innerTextField()
-                        }
-                    }
                 )
             }
 
@@ -346,7 +342,7 @@ internal fun InputDoseView(
                 )
             }
 
-            BasicTextField(
+            HuggTextField(
                 value = dose,
                 onValueChange = { value ->
                     onChangedDose(value)
@@ -360,11 +356,6 @@ internal fun InputDoseView(
                 ),
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
-                decorationBox = { innerTextField ->
-                    CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                        innerTextField()
-                    }
-                }
             )
         }
 
@@ -850,7 +841,7 @@ fun InputMemoView(
                 )
             }
 
-            BasicTextField(
+            HuggTextField(
                 value = memo,
                 onValueChange = { value ->
                     onChangedMemo(value)
@@ -861,11 +852,6 @@ fun InputMemoView(
                 ),
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
-                decorationBox = { innerTextField ->
-                    CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                        innerTextField()
-                    }
-                }
             )
         }
     }

--- a/feature/dailyHugg/src/main/java/com/hugg/dailyhugg/all/DailyHuggListScreen.kt
+++ b/feature/dailyHugg/src/main/java/com/hugg/dailyhugg/all/DailyHuggListScreen.kt
@@ -55,6 +55,7 @@ import com.hugg.feature.theme.GsWhite
 import com.hugg.feature.theme.HuggTypography
 import com.hugg.feature.theme.MainNormal
 import com.hugg.feature.theme.White
+import com.hugg.feature.uiItem.DailyHuggListItem
 import com.hugg.feature.util.TimeFormatter
 
 @Composable
@@ -192,69 +193,6 @@ fun DailyHuggList(
                 interactionSource = interactionSource
             )
             Spacer(modifier = Modifier.height(12.dp))
-        }
-    }
-}
-
-@Composable
-fun DailyHuggListItem(
-    item: DailyHuggListItemVo = DailyHuggListItemVo(),
-    goToDailyHuggDetail: (String) -> Unit = {},
-    interactionSource: MutableInteractionSource
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(60.dp)
-            .clip(RoundedCornerShape(8.dp))
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null,
-                onClick = {
-                    goToDailyHuggDetail(item.date)
-                }
-            )
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxHeight()
-                .clip(RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp))
-                .background(MainNormal),
-            contentAlignment = Alignment.Center
-        ) {
-            HuggText(
-                text = TimeFormatter.getMonthDayWithSlash(item.date),
-                style = HuggTypography.h4,
-                color = GsWhite,
-                modifier = Modifier
-                    .padding(start = 7.dp, end = 6.dp)
-            )
-        }
-
-        Row(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(GsWhite),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Spacer(modifier = Modifier.width(8.dp))
-
-            Icon(
-                painter = painterResource(R.drawable.ic_hugging_female),
-                contentDescription = "",
-                modifier = Modifier
-                    .size(20.dp),
-                tint = Color.Unspecified
-            )
-
-            Spacer(modifier = Modifier.width(8.dp))
-
-            HuggText(
-                text = item.content,
-                style = HuggTypography.p3_l,
-                color = GsBlack,
-                maxLines = 2
-            )
         }
     }
 }

--- a/feature/dailyHugg/src/main/java/com/hugg/dailyhugg/create/CreateDailyHuggScreen.kt
+++ b/feature/dailyHugg/src/main/java/com/hugg/dailyhugg/create/CreateDailyHuggScreen.kt
@@ -56,6 +56,7 @@ import com.hugg.domain.model.enums.TopBarLeftType
 import com.hugg.domain.model.enums.TopBarMiddleType
 import com.hugg.feature.component.FilledBtn
 import com.hugg.feature.component.HuggText
+import com.hugg.feature.component.HuggTextField
 import com.hugg.feature.component.TopBar
 import com.hugg.feature.theme.ALREADY_EXIST_DAILY_HUGG
 import com.hugg.feature.theme.Background
@@ -332,7 +333,7 @@ fun DailyHuggInputField(
             .clip(RoundedCornerShape(8.dp))
             .background(GsWhite)
     ) {
-        BasicTextField(
+        HuggTextField(
             value = content,
             onValueChange = { onDailyHuggContentChanged(it) },
             modifier = Modifier
@@ -341,17 +342,15 @@ fun DailyHuggInputField(
                 .align(Alignment.TopStart),
             textStyle = HuggTypography.p2,
             decorationBox = { innerTextField ->
-                CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)){
-                    if (content.isEmpty()) {
-                        HuggText(
-                            text = DAILY_HUGG_CONTENT_HINT,
-                            color = Color.Gray,
-                            style = HuggTypography.p2,
-                            modifier = Modifier.align(Alignment.TopStart)
-                        )
-                    }
-                    innerTextField()
+                if (content.isEmpty()) {
+                    HuggText(
+                        text = DAILY_HUGG_CONTENT_HINT,
+                        color = Color.Gray,
+                        style = HuggTypography.p2,
+                        modifier = Modifier.align(Alignment.TopStart)
+                    )
                 }
+                innerTextField()
             }
         )
     }

--- a/feature/home/src/main/java/com/hugg/home/homeMain/HomePageState.kt
+++ b/feature/home/src/main/java/com/hugg/home/homeMain/HomePageState.kt
@@ -10,4 +10,5 @@ data class HomePageState(
     val selectedChallengeId : Long = -1,
     val showInputImpressionDialog : Boolean = false,
     val showCompleteChallengeDialog : Boolean = false,
+    val isClickTodo : Boolean = false,
 ) : PageState

--- a/feature/home/src/main/java/com/hugg/home/homeMain/HomePageState.kt
+++ b/feature/home/src/main/java/com/hugg/home/homeMain/HomePageState.kt
@@ -1,12 +1,14 @@
 package com.hugg.home.homeMain
 
 import com.hugg.domain.model.response.challenge.MyChallengeListItemVo
+import com.hugg.domain.model.response.dailyHugg.DailyHuggListItemVo
 import com.hugg.domain.model.vo.home.HomeTodayScheduleCardVo
 import com.hugg.feature.base.PageState
 
 data class HomePageState(
     val todayScheduleList : List<HomeTodayScheduleCardVo> = emptyList(),
     val challengeList: List<MyChallengeListItemVo> = emptyList(),
+    val dailyHuggList: List<DailyHuggListItemVo> = emptyList(),
     val selectedChallengeId : Long = -1,
     val showInputImpressionDialog : Boolean = false,
     val showCompleteChallengeDialog : Boolean = false,

--- a/feature/home/src/main/java/com/hugg/home/homeMain/HomeScreen.kt
+++ b/feature/home/src/main/java/com/hugg/home/homeMain/HomeScreen.kt
@@ -78,6 +78,10 @@ fun HomeContainer(
     }
 
     LaunchedEffect(uiState.todayScheduleList) {
+        if(uiState.isClickTodo){
+            viewModel.updateClickTodoState(false)
+            return@LaunchedEffect
+        }
         val initialPage = uiState.todayScheduleList.indexOfFirst { it.isNearlyNowTime }
         if (initialPage != -1) {
             pagerState.scrollToPage(initialPage)
@@ -232,7 +236,8 @@ fun TodayRecordHorizontalPager(
                 state = pagerState,
                 contentPadding = PaddingValues(start = 16.dp, end = screenWidthDp - itemWidth),
                 modifier = Modifier.fillMaxWidth(),
-                itemSpacing = 8.dp
+                itemSpacing = 8.dp,
+                key = { page -> page }
             ) { page ->
                 HomeTodayScheduleItem(
                     item = itemList[page],

--- a/feature/home/src/main/java/com/hugg/home/homeMain/HomeScreen.kt
+++ b/feature/home/src/main/java/com/hugg/home/homeMain/HomeScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -42,6 +43,7 @@ import com.hugg.domain.model.enums.TopBarLeftType
 import com.hugg.domain.model.enums.TopBarMiddleType
 import com.hugg.domain.model.enums.TopBarRightType
 import com.hugg.domain.model.response.challenge.MyChallengeListItemVo
+import com.hugg.domain.model.response.dailyHugg.DailyHuggListItemVo
 import com.hugg.domain.model.response.home.HomeRecordResponseVo
 import com.hugg.domain.model.vo.home.HomeTodayScheduleCardVo
 import com.hugg.feature.component.ChallengeCompleteDialog
@@ -50,6 +52,7 @@ import com.hugg.feature.component.HuggInputDialog
 import com.hugg.feature.component.HuggText
 import com.hugg.feature.component.TopBar
 import com.hugg.feature.theme.*
+import com.hugg.feature.uiItem.DailyHuggListItem
 import com.hugg.feature.uiItem.HomeMyChallengeItem
 import com.hugg.feature.uiItem.HomeTodayScheduleItem
 import com.hugg.feature.util.HuggToast
@@ -66,6 +69,7 @@ fun HomeContainer(
     navigateGoToChallenge : () -> Unit = {},
     navigateGoToNotification : () -> Unit = {},
     navigateGoToDailyHugg : () -> Unit = {},
+    navigateGoToDailyHuggDetail: (String) -> Unit = {},
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -98,7 +102,8 @@ fun HomeContainer(
         navigateGoToDailyHugg = navigateGoToDailyHugg,
         onClickTodo = { id, time -> viewModel.onClickTodo(id, time) },
         context = context,
-        onClickCompleteChallenge = { id -> viewModel.selectIncompleteChallenge(id)}
+        onClickCompleteChallenge = { id -> viewModel.selectIncompleteChallenge(id)},
+        navigateGoToDailyHuggDetail = navigateGoToDailyHuggDetail
     )
 
     if(uiState.showInputImpressionDialog){
@@ -130,6 +135,7 @@ fun HomeScreen(
     navigateGoToChallenge : () -> Unit = {},
     navigateGoToNotification : () -> Unit = {},
     navigateGoToDailyHugg : () -> Unit = {},
+    navigateGoToDailyHuggDetail : (String) -> Unit = {},
     context : Context,
     onClickCompleteChallenge : (Long) -> Unit = {},
 ) {
@@ -180,6 +186,14 @@ fun HomeScreen(
                         interactionSource = interactionSource,
                         context = context,
                         onClickCompleteChallenge = onClickCompleteChallenge
+                    )
+                }
+                else{
+                    DailyHuggView(
+                        navigateGoToDailyHugg = navigateGoToDailyHugg,
+                        navigateGoToDailyHuggDetail = navigateGoToDailyHuggDetail,
+                        dailyHuggList = uiState.dailyHuggList,
+                        interactionSource = interactionSource
                     )
                 }
             }
@@ -243,7 +257,7 @@ fun TodayRecordHorizontalPager(
                     item = itemList[page],
                     interactionSource = interactionSource,
                     onClickDetail = onClickDetail,
-                    onClickTodo = onClickTodo
+                    onClickTodo = onClickTodo,
                 )
             }
         }
@@ -347,6 +361,73 @@ fun EmptyChallengeView(
                 style = HuggTypography.h4,
                 color = Gs70
             )
+        }
+    }
+}
+
+@Composable
+fun DailyHuggView(
+    navigateGoToDailyHugg: () -> Unit = {},
+    navigateGoToDailyHuggDetail : (String) -> Unit = {},
+    dailyHuggList : List<DailyHuggListItemVo> = emptyList(),
+    interactionSource : MutableInteractionSource
+){
+    Row(
+        modifier = Modifier.padding(horizontal = 16.dp)
+    ) {
+        HuggText(
+            text = DAILY_HUGG,
+            style = HuggTypography.h2,
+            color = Gs90
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Image(
+            modifier = Modifier
+                .padding(top = 1.dp)
+                .onThrottleClick(
+                    onClick = navigateGoToDailyHugg,
+                    interactionSource = interactionSource
+                ),
+            painter = painterResource(id = com.hugg.feature.R.drawable.ic_right_arrow_navigate_gs_50),
+            contentDescription = null,
+        )
+    }
+
+    Spacer(modifier = Modifier.size(8.dp))
+
+    if(dailyHuggList.isEmpty()){
+        Box(
+            modifier = Modifier
+                .background(color = White, shape = RoundedCornerShape(6.dp))
+                .padding(vertical = 20.dp),
+            contentAlignment = Alignment.Center
+        ){
+            HuggText(
+                text = HOME_EMPTY_DAILY_HUGG,
+                style = HuggTypography.h4,
+                color = Gs70
+            )
+        }
+    }
+    else{
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .fillMaxWidth()
+        ) {
+            repeat(dailyHuggList.size){
+                DailyHuggListItem(
+                    item = dailyHuggList[it],
+                    goToDailyHuggDetail = navigateGoToDailyHuggDetail,
+                    interactionSource = interactionSource,
+                    dateColor = if(dailyHuggList[it].date.split(" ")[0] == TimeFormatter.getToday()) MainNormal else Gs40,
+                    borderColor = if(TimeFormatter.getKoreanFullDayOfWeek(dailyHuggList[it].date.split(" ")[0]) == "토요일") Sub else White
+                )
+
+                Spacer(modifier = Modifier.size(8.dp))
+            }
         }
     }
 }

--- a/feature/home/src/main/java/com/hugg/home/homeMain/HomeScreen.kt
+++ b/feature/home/src/main/java/com/hugg/home/homeMain/HomeScreen.kt
@@ -92,7 +92,7 @@ fun HomeContainer(
         navigateGoToChallenge = navigateGoToChallenge,
         navigateGoToNotification = navigateGoToNotification,
         navigateGoToDailyHugg = navigateGoToDailyHugg,
-        onClickTodo = { id -> viewModel.onClickTodo(id) },
+        onClickTodo = { id, time -> viewModel.onClickTodo(id, time) },
         context = context,
         onClickCompleteChallenge = { id -> viewModel.selectIncompleteChallenge(id)}
     )
@@ -122,7 +122,7 @@ fun HomeScreen(
     pagerState : PagerState = rememberPagerState(),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     navigateGoToCalendarDetail : (Long) -> Unit = {},
-    onClickTodo: (Long) -> Unit = {},
+    onClickTodo: (Long, String) -> Unit = {_, _ -> },
     navigateGoToChallenge : () -> Unit = {},
     navigateGoToNotification : () -> Unit = {},
     navigateGoToDailyHugg : () -> Unit = {},
@@ -189,7 +189,7 @@ fun TodayRecordHorizontalPager(
     itemList : List<HomeTodayScheduleCardVo>,
     pagerState: PagerState,
     interactionSource: MutableInteractionSource,
-    onClickTodo : (Long) -> Unit = {},
+    onClickTodo : (Long, String) -> Unit = {_, _ -> },
     onClickDetail : (Long) -> Unit = {},
 ){
     val configuration = LocalConfiguration.current

--- a/feature/home/src/main/java/com/hugg/home/homeMain/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/hugg/home/homeMain/HomeViewModel.kt
@@ -123,11 +123,16 @@ class HomeViewModel @Inject constructor(
     }
 
     fun onClickTodo(id : Long, time : String) {
+        updateClickTodoState(true)
         viewModelScope.launch {
             scheduleRepository.checkTodoRecord(id, time).collect {
                 resultResponse(it, { getHome() })
             }
         }
+    }
+
+    fun updateClickTodoState(isClick : Boolean){
+        updateState(uiState.value.copy(isClickTodo = isClick))
     }
 
     fun selectIncompleteChallenge(id: Long) {

--- a/feature/home/src/main/java/com/hugg/home/homeMain/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/hugg/home/homeMain/HomeViewModel.kt
@@ -61,31 +61,22 @@ class HomeViewModel @Inject constructor(
     private fun handleInitScheduleStatesSuccess(result: HomeResponseVo) {
         updateState(
             uiState.value.copy(
-                todayScheduleList = splitTodayScheduleByRepeatedTime(result.homeRecordResponseVo)
+                todayScheduleList = splitListItem(result.homeRecordResponseVo)
             )
         )
     }
 
-    private fun splitTodayScheduleByRepeatedTime(currentList: List<HomeRecordResponseVo>): List<HomeTodayScheduleCardVo> {
-        val newList = mutableListOf<HomeTodayScheduleCardVo>()
-        for(list in currentList) {
-            val subList = splitListItem(list)
-            newList.addAll(subList)
-        }
-        return updateNearestTime(newList.sortedBy { it.time })
-    }
-
-    private fun splitListItem(list: HomeRecordResponseVo): List<HomeTodayScheduleCardVo> {
-        return list.times.map { repeatTime ->
+    private fun splitListItem(list: List<HomeRecordResponseVo>): List<HomeTodayScheduleCardVo> {
+        return updateNearestTime(list.map {
             HomeTodayScheduleCardVo(
-                id = list.id,
-                recordType = list.recordType,
-                time = repeatTime,
-                name = list.name,
-                memo = list.memo,
-                todo = list.todo
+                id = it.id,
+                recordType = it.recordType,
+                time = it.time,
+                name = it.name,
+                memo = it.memo,
+                todo = it.todo
             )
-        }
+        }.sortedBy { it.time })
     }
 
     private fun updateNearestTime(scheduleList: List<HomeTodayScheduleCardVo>): List<HomeTodayScheduleCardVo> {
@@ -131,9 +122,9 @@ class HomeViewModel @Inject constructor(
         return newList.sortedBy { it.isCompleteToday }
     }
 
-    fun onClickTodo(id : Long) {
+    fun onClickTodo(id : Long, time : String) {
         viewModelScope.launch {
-            scheduleRepository.checkTodoRecord(id).collect {
+            scheduleRepository.checkTodoRecord(id, time).collect {
                 resultResponse(it, { getHome() })
             }
         }

--- a/feature/home/src/main/java/com/hugg/home/homeMain/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/hugg/home/homeMain/HomeViewModel.kt
@@ -4,11 +4,13 @@ import androidx.lifecycle.viewModelScope
 import com.hugg.domain.model.enums.GenderType
 import com.hugg.domain.model.enums.HomeChallengeViewType
 import com.hugg.domain.model.response.challenge.MyChallengeListItemVo
+import com.hugg.domain.model.response.dailyHugg.DailyHuggListResponseVo
 import com.hugg.domain.model.response.home.HomeRecordResponseVo
 import com.hugg.domain.model.response.home.HomeResponseVo
 import com.hugg.domain.model.response.profile.ProfileDetailResponseVo
 import com.hugg.domain.model.vo.home.HomeTodayScheduleCardVo
 import com.hugg.domain.repository.ChallengeRepository
+import com.hugg.domain.repository.DailyHuggRepository
 import com.hugg.domain.repository.HomeRepository
 import com.hugg.domain.repository.ProfileRepository
 import com.hugg.domain.repository.ScheduleRepository
@@ -30,14 +32,15 @@ import kotlin.math.abs
 class HomeViewModel @Inject constructor(
     private val homeRepository: HomeRepository,
     private val scheduleRepository: ScheduleRepository,
-    private val challengeRepository: ChallengeRepository
+    private val challengeRepository: ChallengeRepository,
+    private val dailyHuggRepository: DailyHuggRepository
 ) : BaseViewModel<HomePageState>(
     HomePageState()
 ) {
     fun getHome(){
         getTodayRecord()
         when(UserInfo.info.genderType){
-            GenderType.MALE -> {}
+            GenderType.MALE -> getDailyHuggList()
             GenderType.FEMALE -> getMyChallengeList()
         }
     }
@@ -155,5 +158,21 @@ class HomeViewModel @Inject constructor(
 
     fun updateShowChallengeCompleteDialog(isShow : Boolean){
         updateState(uiState.value.copy(showCompleteChallengeDialog = isShow))
+    }
+
+    private fun getDailyHuggList() {
+        viewModelScope.launch {
+            dailyHuggRepository.getDailyHuggList(0).collect {
+                resultResponse(it, ::onSuccessGetDailyHuggList)
+            }
+        }
+    }
+
+    private fun onSuccessGetDailyHuggList(response: DailyHuggListResponseVo) {
+        updateState(
+            uiState.value.copy(
+                dailyHuggList = response.dailyHuggList.take(3),
+            )
+        )
     }
 }

--- a/feature/main/src/main/java/com/hugg/main/NavExpansions.kt
+++ b/feature/main/src/main/java/com/hugg/main/NavExpansions.kt
@@ -344,7 +344,7 @@ fun NavGraphBuilder.dailyHuggGraph(navController: NavHostController) {
         composable(Routes.DailyHuggCreationSuccessScreen.route) {
             DailyHuggCreationSuccessScreen(
                 goToDailyHuggMain = {
-                    navController.navigate(Routes.DailyHuggScreen.createRoute("")) {
+                    navController.navigate(Routes.DailyHuggScreen.createRoute(TimeFormatter.getToday())) {
                         popUpTo(Routes.DailyHuggGraph.route) { inclusive = true }
                     }
                 }
@@ -436,8 +436,9 @@ fun NavGraphBuilder.homeGraph(navController: NavHostController) {
         composable(Routes.HomeScreen.route) { HomeContainer(
             navigateGoToCalendarDetail = { id -> navController.navigate(Routes.CalendarScheduleCreateOrEdit.getRouteCalendarScheduleCreateOrEdit(CreateOrEditType.EDIT.type, RecordType.ETC.type, id, TimeFormatter.getToday()))},
             navigateGoToChallenge = {},
-            navigateGoToDailyHugg = {},
-            navigateGoToNotification = {}
+            navigateGoToDailyHugg = { navController.navigate(Routes.DailyHuggGraph.route)},
+            navigateGoToNotification = {},
+            navigateGoToDailyHuggDetail = { date -> navController.navigate(Routes.DailyHuggScreen.createRoute(date)) }
         ) }
     }
 }

--- a/feature/main/src/main/java/com/hugg/main/NavExpansions.kt
+++ b/feature/main/src/main/java/com/hugg/main/NavExpansions.kt
@@ -344,7 +344,7 @@ fun NavGraphBuilder.dailyHuggGraph(navController: NavHostController) {
         composable(Routes.DailyHuggCreationSuccessScreen.route) {
             DailyHuggCreationSuccessScreen(
                 goToDailyHuggMain = {
-                    navController.navigate(Routes.DailyHuggScreen.route) {
+                    navController.navigate(Routes.DailyHuggScreen.createRoute("")) {
                         popUpTo(Routes.DailyHuggGraph.route) { inclusive = true }
                     }
                 }

--- a/feature/sign/src/main/java/com/hugg/sign/inputSsn/InputSsnScreen.kt
+++ b/feature/sign/src/main/java/com/hugg/sign/inputSsn/InputSsnScreen.kt
@@ -43,6 +43,7 @@ import com.hugg.domain.model.enums.TopBarLeftType
 import com.hugg.domain.model.enums.TopBarMiddleType
 import com.hugg.feature.component.BlankBtn
 import com.hugg.feature.component.HuggText
+import com.hugg.feature.component.HuggTextField
 import com.hugg.feature.component.SignUpIndicator
 import com.hugg.feature.component.TopBar
 import com.hugg.feature.theme.*
@@ -202,7 +203,7 @@ fun SsnItemView(
             .background(White),
         contentAlignment = Alignment.Center
     ){
-        BasicTextField(
+        HuggTextField(
             modifier = Modifier
                 .focusRequester(focusRequester)
                 .onPreviewKeyEvent { event ->
@@ -219,11 +220,6 @@ fun SsnItemView(
                 textAlign = TextAlign.Center
             ),
             singleLine = true,
-            decorationBox = { innerTextField ->
-                CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                    innerTextField()
-                }
-            }
         )
     }
 }

--- a/feature/sign/src/main/java/com/hugg/sign/maleSignUp/MaleSignUpScreen.kt
+++ b/feature/sign/src/main/java/com/hugg/sign/maleSignUp/MaleSignUpScreen.kt
@@ -32,6 +32,7 @@ import com.hugg.domain.model.enums.TopBarMiddleType
 import com.hugg.domain.model.request.sign.SignUpMaleRequestVo
 import com.hugg.feature.component.FilledBtn
 import com.hugg.feature.component.HuggText
+import com.hugg.feature.component.HuggTextField
 import com.hugg.feature.component.SignUpIndicator
 import com.hugg.feature.component.TopBar
 import com.hugg.feature.theme.*
@@ -117,7 +118,7 @@ fun MaleSignUpScreen(
                 ),
                 contentAlignment = Alignment.Center
             ){
-                BasicTextField(
+                HuggTextField(
                     value = uiState.spouseCode,
                     onValueChange = { value ->
                         onChangedSpouseCode(value)
@@ -127,11 +128,6 @@ fun MaleSignUpScreen(
                         textAlign = TextAlign.Center
                     ),
                     singleLine = true,
-                    decorationBox = { innerTextField ->
-                        CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                            innerTextField()
-                        }
-                    }
                 )
             }
 

--- a/feature/src/main/java/com/hugg/feature/component/HuggDialog.kt
+++ b/feature/src/main/java/com/hugg/feature/component/HuggDialog.kt
@@ -195,7 +195,7 @@ fun HuggInputDialog(
 
             Spacer(modifier = Modifier.size(8.dp))
 
-            BasicTextField(
+            HuggTextField(
                 value = inputContent,
                 onValueChange = { value ->
                     if (value.length <= maxLength) {
@@ -212,11 +212,6 @@ fun HuggInputDialog(
                     .fillMaxWidth()
                     .border(width = 1.dp, color = Gs30, shape = RoundedCornerShape(4.dp))
                     .padding(vertical = 12.dp),
-                decorationBox = { innerTextField ->
-                    CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)) {
-                        innerTextField()
-                    }
-                }
             )
 
             Spacer(modifier = Modifier.size(5.dp))

--- a/feature/src/main/java/com/hugg/feature/component/HuggTextField.kt
+++ b/feature/src/main/java/com/hugg/feature/component/HuggTextField.kt
@@ -1,0 +1,103 @@
+package com.hugg.feature.component
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.Density
+
+@Composable
+fun HuggTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = TextStyle.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    cursorBrush: Brush = SolidColor(Color.Black),
+    decorationBox: @Composable (innerTextField: @Composable () -> Unit) -> Unit =
+        @Composable { innerTextField -> innerTextField() }
+) {
+    CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)){
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = modifier,
+            enabled = enabled,
+            readOnly = readOnly,
+            textStyle = textStyle,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            singleLine = singleLine,
+            maxLines = maxLines,
+            minLines = minLines,
+            visualTransformation = visualTransformation,
+            onTextLayout = onTextLayout,
+            interactionSource = interactionSource,
+            cursorBrush = cursorBrush,
+            decorationBox = decorationBox
+        )
+    }
+}
+
+@Composable
+fun HuggTextField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = TextStyle.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    cursorBrush: Brush = SolidColor(Color.Black),
+    decorationBox: @Composable (innerTextField: @Composable () -> Unit) -> Unit =
+        @Composable { innerTextField -> innerTextField() }
+) {
+    CompositionLocalProvider(LocalDensity provides Density(density = LocalDensity.current.density, fontScale = 1f)){
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = modifier,
+            enabled = enabled,
+            readOnly = readOnly,
+            textStyle = textStyle,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            singleLine = singleLine,
+            maxLines = maxLines,
+            minLines = minLines,
+            visualTransformation = visualTransformation,
+            onTextLayout = onTextLayout,
+            interactionSource = interactionSource,
+            cursorBrush = cursorBrush,
+            decorationBox = decorationBox
+        )
+    }
+}

--- a/feature/src/main/java/com/hugg/feature/theme/StringComponent.kt
+++ b/feature/src/main/java/com/hugg/feature/theme/StringComponent.kt
@@ -302,6 +302,7 @@ const val HOME_MY_CHALLENGE = "생활습관 챌린지"
 const val HOME_EMPTY_MY_CHALLENGE_TITLE = "챌린지에 참여해 보세요."
 const val HOME_EMPTY_MY_CHALLENGE_CONTENT = "어쩌구 저쩌구 다양한 생활 습관 챌린지를 같이 할 수 있어요"
 const val HOME_PARTICIPATE_CHALLENGE = "챌린지 참여"
+const val HOME_EMPTY_DAILY_HUGG = "아직 작성된 배우자의 데일리 허그가 없어요."
 
 // --------- 챌린지 --------- //
 const val CHALLENGE_DIALOG_INPUT_IMPRESSION_TITLE = "한 줄 소감을 입력해주세요"

--- a/feature/src/main/java/com/hugg/feature/uiItem/DailyHuggListItem.kt
+++ b/feature/src/main/java/com/hugg/feature/uiItem/DailyHuggListItem.kt
@@ -1,0 +1,102 @@
+package com.hugg.feature.uiItem
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.hugg.domain.model.response.dailyHugg.DailyHuggListItemVo
+import com.hugg.feature.R
+import com.hugg.feature.component.HuggText
+import com.hugg.feature.theme.GsBlack
+import com.hugg.feature.theme.GsWhite
+import com.hugg.feature.theme.HuggTypography
+import com.hugg.feature.theme.MainNormal
+import com.hugg.feature.theme.White
+import com.hugg.feature.util.TimeFormatter
+import com.hugg.feature.util.onThrottleClick
+
+@Composable
+fun DailyHuggListItem(
+    item: DailyHuggListItemVo = DailyHuggListItemVo(),
+    goToDailyHuggDetail: (String) -> Unit = {},
+    interactionSource: MutableInteractionSource,
+    dateColor : Color = MainNormal,
+    borderColor : Color = White
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(60.dp)
+            .onThrottleClick(
+                interactionSource = interactionSource,
+                onClick = {
+                    goToDailyHuggDetail(item.date)
+                }
+            )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = White, shape = RoundedCornerShape(8.dp))
+                .border(width = 1.dp, color = borderColor, shape = RoundedCornerShape(8.dp)),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Spacer(modifier = Modifier.width(60.dp))
+
+            Icon(
+                painter = painterResource(R.drawable.ic_hugging_female),
+                contentDescription = "",
+                modifier = Modifier
+                    .size(20.dp),
+                tint = Color.Unspecified
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            HuggText(
+                text = item.content,
+                style = HuggTypography.p3_l,
+                color = GsBlack,
+                maxLines = 2
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .width(52.dp)
+                .clip(RoundedCornerShape(topStart = 8.dp, bottomStart = 8.dp))
+                .background(dateColor),
+            contentAlignment = Alignment.Center
+        ) {
+            HuggText(
+                text = TimeFormatter.getMonthDayWithSlash(item.date),
+                style = HuggTypography.h4,
+                color = GsWhite,
+            )
+        }
+    }
+}

--- a/feature/src/main/java/com/hugg/feature/uiItem/HomeTodayScheduleItem.kt
+++ b/feature/src/main/java/com/hugg/feature/uiItem/HomeTodayScheduleItem.kt
@@ -46,7 +46,7 @@ import com.hugg.feature.util.onThrottleClick
 @Composable
 fun HomeTodayScheduleItem(
     item : HomeTodayScheduleCardVo = HomeTodayScheduleCardVo(),
-    onClickTodo : (Long) -> Unit = {},
+    onClickTodo : (Long, String) -> Unit = {_, _ -> },
     onClickDetail : (Long) -> Unit = {},
     interactionSource: MutableInteractionSource
 ){
@@ -81,7 +81,7 @@ fun HomeTodayScheduleItem(
             Column(
                 modifier = Modifier
                     .onThrottleClick(
-                        onClick = { onClickTodo(item.id) },
+                        onClick = { onClickTodo(item.id, item.time) },
                         interactionSource = interactionSource
                     )
             ){

--- a/feature/src/main/java/com/hugg/feature/util/TimeFormatter.kt
+++ b/feature/src/main/java/com/hugg/feature/util/TimeFormatter.kt
@@ -8,6 +8,7 @@ import org.threeten.bp.LocalTime
 import org.threeten.bp.format.DateTimeFormatter
 import org.threeten.bp.format.DateTimeFormatterBuilder
 import org.threeten.bp.format.TextStyle
+import org.threeten.bp.temporal.ChronoField
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -236,7 +237,13 @@ object TimeFormatter {
     }
 
     fun getMonthDayWithSlash(date: String): String {
-        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        val formatter = DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH:mm:ss")
+            .optionalStart()
+            .appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true)
+            .optionalEnd()
+            .toFormatter()
+
         val dateTime = LocalDateTime.parse(date, formatter)
         val outputFormatter = DateTimeFormatter.ofPattern("MM/dd")
 


### PR DESCRIPTION
## 이슈 번호
> 작업이 완료된 이슈의 번호를 기록해주세요.

close #44 

## 작업내용
> 작업한 내용을 설명해주세요. 왜 수정했는지? 무엇을 구현했는지? 등등

홈 화면에서 남편 계정으로 접속했을 때 보여지는 데일리 허그 기능을 추가했습니다.
추가로, BasicTextField의 fontSize가 제대로 적용이 되지 않은 오류, todoCheck 오류, 데일리허그에서 navigate 오류 등 문제를 해결했습니다.
앞으로 작업하실 때 `Text`는 `HuggText`로, `BasicTextField`는 `HuggTextField`로 사용해주시면 됩니다.
또한 중복 터치가 가능할 것 같은 터치박스는 꼭 `throttleClick`으로 적용해주시기 바랍니다! modifier에 확장자로 자세한 내용은 #35 여기에 있습니다. 

## 결과물
> 구현한 것 스크린샷 또는 영상 또는 gif 형태로 올려주세요.


https://github.com/user-attachments/assets/474aff73-51d7-44f4-8b37-30a54d714f80





## 리뷰어에게 추가로 요구하는 사항(선택)
> 이 부분을 자세히 봐야한다 또는 함수 로직에 확신이 없는데 더 좋은 방법이 있을까요? 등등

이제 저의 남은 기능은 챌린지와 알림 페이지 입니다.. 챌린지는 형님 파트 완료되면 바로 적용할 예정이고 알림 페이지도 기획이 완료되는대로 추가하겠습니다!